### PR TITLE
Feat: Response객체 수정, cgi결과의 처리와 upload 처리의 로직 분할

### DIFF
--- a/src/Client/Client.cpp
+++ b/src/Client/Client.cpp
@@ -116,13 +116,13 @@ int			Client::read_pipe_result()
 	}
 
 	// Client의 Response 객체 생성하기
-	res = new Response();
-	Response::ResponseInit();
-	res->setStatusCode(req->getStatusCode());
-	res->setHeaders("Content-type", "text/html; charset=UTF-8");
+	res = new Response(req->getStatusCode());
 	// 파일 다운로드 응답인 경우에 아래 헤더 추가
 	//res->setHeaders("Content-Disposition", "attachment; filename=\"cool.html\"");
-	res->makeContent(result);
+	res->cgiResponse(result);  // cgi 응답인 경우
+
+	// 파일 업로드 요청인 경우
+	//res->uploadResponse(req->getReqHeaderValue("Content-type"), req->getReqBody());
 
 	close(pipe_fd);
 	return (0);

--- a/src/response/response.hpp
+++ b/src/response/response.hpp
@@ -3,26 +3,33 @@
 
 # include <string>
 # include <map>
+# include <fstream>
+# include <unistd.h>
 
 using namespace std;
 
 class Response {
 private:
 	static map<int, string>	m_status_description;
+	static bool				is_init;
 	int						m_status_code;
 	map<string, string>		m_headers;
 	string					m_content;
 	string					m_cgiResult;
 
 	string		makeHeaders();
+	string		parseHeader(string& content_type);
+	string		getFileContent(string& content_type);
 
 public:
 	// 왜 private??
 	Response ();
+	Response (int status);
 	~Response ();
 
 	static void	ResponseInit(); // Response 클래스를 초기화하는 한번만 실행 가능함수
-	void		makeContent(string ret);
+	void		makeCgiContent(string ret);
+	void		makeUploadContent();
 
 	int					getStatusCode();
 	map<int ,string>	getStatusDesc();
@@ -34,6 +41,11 @@ public:
 	void		setHeaders(string key, string value);
 	void		setCgiResult(string ret);
 	void		setContent(string content);
+
+	void		saveFile(string content_type, string content_body);  // m_content로 받을 데이터를 파싱해서 파일로 저장하는 함수
+
+	void		cgiResponse(string cgi_result);  // cgi 결과를 요청하는 경우의 응답
+	void		uploadResponse(string content_type, string content_body);  // 파일 업로드 경우의 응답과 처리
 
 	string		getHttpResponse();
 };


### PR DESCRIPTION
Response 객체의 초기화 방식을 바꾸고, 상태코드를 인자로 받는 생성자를 추가함.

Response 메시지를 만들 때, cgi결과 응답인 경우와, file upload 응답의 경우를 나누었음